### PR TITLE
JS was erroring out because the xaxis was being 'set' pre definition

### DIFF
--- a/components/js/go-content-stats.js
+++ b/components/js/go-content-stats.js
@@ -247,6 +247,7 @@ if ( undefined === go_content_stats ) {
 		this.stats = {};
 		var tmp_stats = {};
 		var zoom = this.get_zoom();
+		var xaxis = null;
 
 		if ( 'day' === zoom ) {
 			tmp_stats = this.day_stats;


### PR DESCRIPTION
This error prevented any data from appearing in my local instance. Once cleared up, data and graphs were displayed.  I noted that the same error was occurring in the link that @misterbisson provided in the issue.

See: https://github.com/GigaOM/gigaom/issues/4576 and https://github.com/GigaOM/legacy-pro/issues/3402
