### PR TITLE
Revert "Revert "Add fill_post_ids method""

### DIFF
--- a/components/class-go-content-stats-wp-cli.php
+++ b/components/class-go-content-stats-wp-cli.php
@@ -58,8 +58,23 @@ class GO_Content_Stats_WP_CLI extends WP_CLI_Command
 		go_content_stats()->load()->load_range( $start, $end );
 
 		WP_CLI::line( 'Finished fetching analytics data.' );
-		WP_CLI::line( 'Filling GUIDs.' );
 
+		$this->fill_post_ids();
+	}//end fetch
+
+	/**
+	 * fills post ids on records that are missing them
+	 *
+	 * ## OPTIONS
+	 *     none
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp go_content_stats fill_post_ids
+	 */
+	public function fill_post_ids()
+	{
+		WP_CLI::line( 'Filling GUIDs.' );
 		$count = 1;
 		$time = time();
 		while ( $count > 0 )
@@ -73,5 +88,5 @@ class GO_Content_Stats_WP_CLI extends WP_CLI_Command
 		}// end while
 
 		WP_CLI::success( 'Post IDs filled.' );
-	}//end fetch
+	}//end fill_post_ids
 }//end class


### PR DESCRIPTION
Reverts GigaOM/go-content-stats#27

Original ticket: https://github.com/GigaOM/gigaom/issues/4812

I committed to master when I shouldn't have. This reverts my revert and puts the [already code reviewed code](https://github.com/GigaOM/go-content-stats/pull/26) _back_ into master.
