### PR TITLE
adding indices to custom storage table

### DIFF
--- a/components/class-go-content-stats-storage.php
+++ b/components/class-go-content-stats-storage.php
@@ -354,7 +354,8 @@ class GO_Content_Stats_Storage
 				`added_timestamp` timestamp DEFAULT 0,
 				PRIMARY KEY (id),
 				KEY `date` (`date`),
-				KEY `post_id` (`post_id`)
+				KEY `post_id` (`post_id`),
+  				KEY `url_property` (`property`(2),`url`)
 			) ENGINE=InnoDB $charset_collate
 		";
 


### PR DESCRIPTION
We also need an index added to `wp_3_posts` on `guid`

This was omitted from https://github.com/GigaOM/go-content-stats/pull/23

In reference to https://github.com/GigaOM/gigaom/issues/4590
