### PR TITLE
Attempt to cache wp_remote_get calls and update by ID rather than URL

### DIFF
--- a/components/class-go-content-stats-storage.php
+++ b/components/class-go-content-stats-storage.php
@@ -375,8 +375,7 @@ class GO_Content_Stats_Storage
 				`added_timestamp` timestamp DEFAULT 0,
 				PRIMARY KEY (id),
 				KEY `date` (`date`),
-				KEY `post_id` (`post_id`),
-  				KEY `url_property` (`property`(2),`url`)
+				KEY `post_id` (`post_id`)
 			) ENGINE=InnoDB $charset_collate
 		";
 


### PR DESCRIPTION
This PR works better with [`?w=1`](https://github.com/GigaOM/go-content-stats/pull/37/files?w=1)

See: https://github.com/GigaOM/legacy-pro/issues/3820#issuecomment-49615577
