### PR TITLE
bugfixing go-content-stats

### DIFF
--- a/components/class-go-content-stats-storage.php
+++ b/components/class-go-content-stats-storage.php
@@ -280,6 +280,11 @@ class GO_Content_Stats_Storage
 
 		$count = 0;
 
+		if ( ! count( $records ) )
+		{
+			return 0;
+		}
+
 		foreach ( $records as $row )
 		{
 			$post_id = -1; // couldn't find a GUID

--- a/components/class-go-content-stats-wp-cli.php
+++ b/components/class-go-content-stats-wp-cli.php
@@ -100,12 +100,12 @@ class GO_Content_Stats_WP_CLI extends WP_CLI_Command
 		}// end if
 
 		WP_CLI::line( 'Filling GUIDs from ' . date( 'Y-m-d', $start ) . ' => ' . date( 'Y-m-d', $end ) . '...' );
-		$count = 1;
-		$time = time();
-		$date = $start;
 
+		$date = $start;
 		while ( $date <= $end )
 		{
+			$count = 1;
+			$time = time();
 			while ( $count > 0 )
 			{
 				$count = go_content_stats()->storage()->fill_post_id( date( 'Y-m-d', $date ) );
@@ -116,7 +116,7 @@ class GO_Content_Stats_WP_CLI extends WP_CLI_Command
 				$time = $new_time;
 			}// end while
 
-			$date = strtotime( '+1 day', strtotime( $date ) );
+			$date += 86400; // +1 day
 		}//end while
 
 		WP_CLI::success( 'Post IDs filled from ' . date( 'Y-m-d', $start ) . ' => ' . date( 'Y-m-d', $end ) . '.' );


### PR DESCRIPTION
See https://github.com/GigaOM/gigaom/issues/4980

Fixing some stuff I overlooked in https://github.com/GigaOM/go-content-stats/pull/40

Specifically:
- Check the count of rows and return early if its empty.
- Reset the count before each while(), so everybody gets a fair shake.
