### PR TITLE
jquery-blockui -> blockui

### DIFF
--- a/components/class-go-content-stats.php
+++ b/components/class-go-content-stats.php
@@ -263,7 +263,7 @@ class GO_Content_Stats
 				'bootstrap-daterangepicker',
 				'rickshaw',
 				'handlebars',
-				'jquery-blockui',
+				'blockui',
 			),
 			$script_config['version'],
 			TRUE


### PR DESCRIPTION
- jquery-blockui was changed to blockui which was preventing go-content-stats JS from loading.

https://github.com/GigaOM/legacy-pro/issues/4534
