### PR TITLE
Query for posts via url before we wp_remote_get

### DIFF
--- a/components/class-go-content-stats-load.php
+++ b/components/class-go-content-stats-load.php
@@ -127,6 +127,7 @@ class GO_Content_Stats_Load
 			$stat_row = array(
 				'date' => $date,
 				'property' => $property,
+				// this needs to remain http because that matches the guid
 				'url' => 'http://' .  $row[1] . $row[0],
 				'views' => $row[2],
 			);


### PR DESCRIPTION
Big performance boost.

See: https://github.com/GigaOM/legacy-pro/issues/4602

This replaces: https://github.com/GigaOM/go-content-stats/pull/43
